### PR TITLE
Implement Supabase profile update and streamlined logout

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,42 +21,13 @@ export default function Header() {
   const [isAddBookmarkOpen, setIsAddBookmarkOpen] = useState(false);
   const navigate = useNavigate();
   
-  // 로그아웃 핸들러 - 디버그 로그 추가 및 개선
+  // 간단한 로그아웃 핸들러
   const handleLogout = async () => {
-    console.log('헤더에서 로그아웃 시도 - 디버그 버전');
-    
+    setIsAddBookmarkOpen(false);
     try {
-      // 1. 상태 초기화 먼저 실행
-      setIsAddBookmarkOpen(false); // 다이얼로그 닫기
-      
-      // 2. Supabase 로그아웃 API 호출 전 상태 확인
-      const session = await supabase.auth.getSession();
-      console.log('로그아웃 전 세션 상태:', session);
-      
-      // 3. Supabase 로그아웃 API 호출
-      console.log('Supabase signOut API 호출 시작...');
-      const { error } = await supabase.auth.signOut();
-      
-      if (error) {
-        console.error('로그아웃 API 오류:', error);
-        return;
-      }
-      
-      // 4. 로그아웃 후 세션 확인
-      const afterSession = await supabase.auth.getSession();
-      console.log('로그아웃 후 세션 상태:', afterSession);
-      
-      // 5. 상태 강제 초기화
-      console.log('상태 강제 초기화 및 홈페이지로 리다이렉트');
-      
-      // 6. 직접 새로고침 방식으로 홈페이지로 이동
-      setTimeout(() => {
-        window.location.href = '/';
-      }, 500);
-      
-    } catch (error) {
-      console.error('로그아웃 처리 중 오류:', error);
-      alert('로그아웃 처리 중 오류가 발생했습니다. 페이지를 새로고침해 주세요.');
+      await logout(() => navigate('/'));
+    } catch (e) {
+      console.error('로그아웃 처리 중 오류:', e);
     }
   };
 
@@ -139,15 +110,8 @@ export default function Header() {
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem asChild>
-                    <button 
-                      onClick={(e) => {
-                        e.preventDefault();
-                        console.log('로그아웃 버튼 클릭됨');
-                        // 로컬 스토리지 및 쿠키 초기화
-                        localStorage.removeItem('supabase.auth.token');
-                        // 페이지 새로고침
-                        window.location.href = '/';
-                      }}
+                    <button
+                      onClick={handleLogout}
                       className="w-full flex items-center text-red-500 cursor-pointer"
                     >
                       <LogOut className="mr-2 h-4 w-4" />

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -314,3 +314,15 @@ export const collectionApi = {
     if (error) throw error
   }
 } 
+export const profileApi = {
+  async update(id: string, updates: { nickname?: string; avatar_url?: string }) {
+    const { data, error } = await supabase
+      .from('profiles')
+      .upsert({ id, ...updates })
+      .select()
+      .single()
+
+    if (error) throw error
+    return data
+  }
+}


### PR DESCRIPTION
## Summary
- update `profileApi` in `supabase.ts` to allow profile updates
- save nickname edits from profile page to Supabase
- simplify logout logic to use AuthContext's logout handler

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684031c0760c832a9ecba48a085c8f53