### PR TITLE
Fix bookmark deletion via direct API fallback

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -237,6 +237,38 @@ export const bookmarkApi = {
   }
 }
 
+// 북마크 직접 삭제 (Supabase 클라이언트 우회)
+export const directBookmarkDelete = async (id: string, accessToken?: string) => {
+  try {
+    const headers: HeadersInit = {
+      'apikey': supabaseAnonKey
+    };
+
+    if (accessToken) {
+      headers['Authorization'] = `Bearer ${accessToken}`;
+    }
+
+    const response = await fetch(
+      `${supabaseUrl}/rest/v1/bookmarks?id=eq.${id}`,
+      {
+        method: 'DELETE',
+        headers
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.json();
+      console.error('직접 북마크 삭제 실패:', error);
+      return { error };
+    }
+
+    return { error: null };
+  } catch (error) {
+    console.error('직접 북마크 삭제 오류:', error);
+    return { error };
+  }
+};
+
 // 컬렉션 관련 함수
 export const collectionApi = {
   // 컬렉션 생성


### PR DESCRIPTION
## Summary
- add `directBookmarkDelete` helper to handle Supabase REST deletion
- call new helper in `BookmarkContext.deleteBookmark` when client removal fails

## Testing
- `npm run lint` *(fails: 27 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6840710cc050832a9a96b4ce780813e5