### PR TITLE
Fix bookmark load after refresh

### DIFF
--- a/src/contexts/BookmarkContext.tsx
+++ b/src/contexts/BookmarkContext.tsx
@@ -85,6 +85,11 @@ export const BookmarkProvider = ({ children }: { children: ReactNode }) => {
       setIsLoading(true);
       try {
         if (user) {
+          try {
+            await supabase.auth.refreshSession();
+          } catch (e) {
+            console.warn('세션 갱신 실패:', e);
+          }
           console.log('[BookmarkProvider] 북마크 Supabase API 호출 직전', user.id);
           const { data: bookmarksData, error: bookmarksError } = await supabase
             .from('bookmarks')


### PR DESCRIPTION
## Summary
- refresh Supabase session before fetching data to avoid stale auth

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842f7902b1c832aaa13d43129c5e94d