### PR TITLE
Fix bookmark insertion tags

### DIFF
--- a/src/contexts/BookmarkContext.tsx
+++ b/src/contexts/BookmarkContext.tsx
@@ -254,7 +254,7 @@ export const BookmarkProvider = ({ children }: { children: ReactNode }) => {
         description: description || metadata.description || '',
         image_url: metadata.thumbnail || '', // image_url 컬럼 있음
         folder_id: folderId,
-        tags: JSON.stringify(tagNames),
+        tags: tagNames,
         // created_at, updated_at은 DB에서 자동 생성
       };
       

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -35,7 +35,7 @@ export interface Bookmark {
   image_url: string | null
   created_at: string
   updated_at: string
-  tags: string
+  tags: string[]
 }
 
 export type Collection = {


### PR DESCRIPTION
## Summary
- send bookmark tags as an array
- update Supabase types accordingly

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components and @typescript-eslint rules)*

------
https://chatgpt.com/codex/tasks/task_e_6843d9098148832a8b18977c411cc3bc