### PR TITLE
Fix repeated profile fetch in auth handler

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -116,6 +116,12 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       setIsLoading(false);
       return;
     }
+    if (userState && userState.id === session.user.id) {
+      console.log('[handleSession] 기존 사용자 상태가 존재합니다. 프로필 재요청을 생략합니다.');
+      setIsAuthenticated(true);
+      setIsLoading(false);
+      return;
+    }
     try {
       const userData = session.user;
       console.log('세션 처리 시작:', {


### PR DESCRIPTION
## Summary
- stop fetching profile on token refresh when user state already loaded

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843dbb18d6c832a8c9b7e3dbd7abbd5