### PR TITLE
Improve mobile usability of Add Bookmark dialog

### DIFF
--- a/src/components/bookmark/AddBookmarkDialog.tsx
+++ b/src/components/bookmark/AddBookmarkDialog.tsx
@@ -66,11 +66,11 @@ export default function AddBookmarkDialog({ open, onOpenChange, defaultFolderId 
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="flex w-[calc(100vw-1.5rem)] max-w-md max-h-[calc(100dvh-1.5rem)] flex-col overflow-hidden p-0 sm:max-h-[90dvh]">
         <DialogHeader>
-          <DialogTitle>새 북마크 추가</DialogTitle>
+          <DialogTitle className="px-6 pt-6">새 북마크 추가</DialogTitle>
         </DialogHeader>
-        <div className="space-y-4 py-4">
+        <div className="flex-1 space-y-4 overflow-y-auto px-6 py-4">
           <div className="flex items-center space-x-2">
             <Link className="h-5 w-5 shrink-0 text-muted-foreground" />
             <Input
@@ -146,7 +146,7 @@ export default function AddBookmarkDialog({ open, onOpenChange, defaultFolderId 
             />
           </div>
         </div>
-        <div className="flex justify-end gap-2">
+        <div className="flex justify-end gap-2 border-t bg-background px-6 py-4">
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}


### PR DESCRIPTION
### Motivation
- The Add Bookmark dialog was too tall on small screens, preventing scrolling and hiding the action buttons, so it needed layout changes to work on mobile viewports.

### Description
- Constrain the dialog to the viewport by changing `DialogContent` classes to `w-[calc(100vw-1.5rem)]` and `max-h-[calc(100dvh-1.5rem)]` and add `sm:max-h-[90dvh]` to improve mobile fit.
- Make the form body scrollable by using `flex-1` and `overflow-y-auto` on the content container so long forms can scroll while the footer stays visible.
- Add consistent inner padding (`px-6 py-4` / `px-6 pt-6`) and a footer divider (`border-t bg-background px-6 py-4`) so action buttons remain accessible and visually separated.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served successfully.
- Captured a mobile viewport screenshot via a Playwright script to verify the dialog is scrollable and buttons are visible; the script completed and produced the artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cdb3ba9a0832aa96c0f36c4a7073e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the Add Bookmark dialog layout with improved spacing, scrolling behavior, and visual organization of form elements and action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->